### PR TITLE
Make rustfmt&clippy run on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry { run: false, version: "nightly", allow_failure: false, install_commandline: None, commandline: "cargo bench" }, clippy: ClippyEntry { run: true, version: "nightly", allow_failure: false, install_commandline: None, commandline: "cargo clippy -- -D warnings" }, rustfmt: RustfmtEntry { run: true, version: "stable", allow_failure: false, install_commandline: None, commandline: "cargo fmt" }, additional_matrix_entries: {"something_custom": CustomEntry { run: false, version: "stable", allow_failure: false, install_commandline: Some("echo \"installing for custom tests\""), commandline: "echo \"running custom tests\"" }}, os: "linux", dist: "xenial", versions: ["stable", "beta", "nightly"], test_commandline: "cargo test --verbose --all" }
+# TemplateCIConfig { bench: BenchEntry { run: false, version: "nightly", allow_failure: false, install_commandline: None, commandline: "cargo bench" }, clippy: ClippyEntry { run: true, version: "stable", allow_failure: false, install_commandline: None, commandline: "cargo clippy -- -D warnings" }, rustfmt: RustfmtEntry { run: true, version: "stable", allow_failure: false, install_commandline: None, commandline: "cargo fmt" }, additional_matrix_entries: {"something_custom": CustomEntry { run: false, version: "stable", allow_failure: false, install_commandline: Some("echo \"installing for custom tests\""), commandline: "echo \"running custom tests\"" }}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "beta", "nightly"], test_commandline: "cargo test --verbose --all" }
 os:
   - "linux"
 dist: "xenial"
@@ -28,7 +28,7 @@ matrix:
         - RUN_RUSTFMT=true
         - RUN_TEST=false
     - &clippy_build
-      rust: "nightly"
+      rust: "stable"
       env:
         - RUN_CLIPPY=true
         - RUN_TEST=false
@@ -41,12 +41,12 @@ matrix:
 
 before_script:
   - bash -c 'if [[ "$RUN_RUSTFMT" == "true" ]]; then
-      rustup component add rustfmt-preview
+      rustup component add rustfmt
       ;
     fi'
   - bash -c 'if [[ "$RUN_CLIPPY" == "true" ]]; then
       rm -f ~/.cargo/bin/clippy;
-      rustup component add clippy-preview
+      rustup component add clippy
       ;
     fi'
   - bash -c 'if [[ "$RUN_SOMETHING_CUSTOM" == "true" ]]; then

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ define_matrix_entry!(
     ClippyEntry,
     (
         true,
-        "nightly",
+        "stable",
         false,
         Some("cargo clippy -- -D warnings".to_owned())
     )

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -65,14 +65,14 @@ matrix:
 before_script:
   {%- if rustfmt.run %}
   - bash -c 'if [[ "$RUN_RUSTFMT" == "true" ]]; then
-      rustup component add rustfmt-preview
+      rustup component add rustfmt
       ;
     fi'
   {%- endif %}
   {%- if clippy.run %}
   - bash -c 'if [[ "$RUN_CLIPPY" == "true" ]]; then
       rm -f ~/.cargo/bin/clippy;
-      rustup component add clippy-preview
+      rustup component add clippy
       ;
     fi'
   {%- endif %}


### PR DESCRIPTION
This PR makes both rustfmt and clippy run on stable, and installs the
`rustfmt` and `clippy` components instead of their respective
`-preview` counterparts.