### PR TITLE
Set up a cronjob for circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry { run: false, version: "nightly", install_commandline: None, commandline: "cargo bench" }, clippy: ClippyEntry { run: true, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }, rustfmt: RustfmtEntry { run: true, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }, additional_matrix_entries: {"something_custom": CustomEntry { run: false, version: "stable", install_commandline: Some("echo \"installing for custom tests\""), commandline: "echo \"running custom tests\"" }}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all" }
+# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: false, version: "nightly", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"something_custom": CustomEntry(MatrixEntry { run: false, version: "stable", install_commandline: Some("echo \"installing for custom tests\""), commandline: "echo \"running custom tests\"" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
 version: "2.1"
 
 executors:
@@ -24,14 +24,18 @@ commands:
           command: "rustc --version"
       - run:
           name: Test
-          command: "cargo test"
+          command: cargo test --verbose --all
 
 jobs:
   test:
     parameters:
       version:
         type: executor
+      version_name:
+        type: string
     executor: << parameters.version >>
+    environment:
+      CI_RUST_VERSION: << parameters.version_name >>
     steps:
       - checkout
       - cargo_test
@@ -89,6 +93,7 @@ workflows:
       - test:
           name: test-stable
           version: stable
+          version_name: stable
           filters: {
   "branches": {
     "ignore": [
@@ -104,6 +109,7 @@ workflows:
       - test:
           name: test-nightly
           version: nightly
+          version_name: nightly
           filters: {
   "branches": {
     "ignore": [
@@ -150,3 +156,21 @@ workflows:
           - test-nightly
           - rustfmt
           - clippy
+  scheduled_tests:
+    jobs:
+      - test:
+          name: test-stable
+          version: stable
+          version_name: stable
+      - test:
+          name: test-nightly
+          version: nightly
+          version_name: nightly
+    triggers:
+      - schedule:
+          cron: 0 0 * * 0
+        filters:
+          branches:
+            only: [
+  "master"
+]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,8 @@ workflows:
     triggers:
       - schedule:
           cron: 0 0 * * 0
-        filters:
-          branches:
-            only: [
+          filters:
+            branches:
+              only: [
   "master"
 ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,12 @@ pub(crate) struct TemplateCIConfig {
 
     #[serde(default = "TemplateCIConfig::default_test_commandline")]
     pub(crate) test_commandline: String,
+
+    #[serde(default = "TemplateCIConfig::default_scheduled_test_branches")]
+    pub(crate) scheduled_test_branches: Vec<String>,
+
+    #[serde(default = "TemplateCIConfig::default_test_schedule")]
+    pub(crate) test_schedule: String,
 }
 
 impl Default for TemplateCIConfig {
@@ -120,6 +126,8 @@ impl Default for TemplateCIConfig {
                 .map(String::from)
                 .collect(),
             test_commandline: "cargo test --verbose --all".to_owned(),
+            scheduled_test_branches: vec!["master"].into_iter().map(String::from).collect(),
+            test_schedule: "0 0 * * 0".to_string(), // every sunday at 0:00 UTC
         }
     }
 }
@@ -173,6 +181,14 @@ impl<'a> TemplateCIConfig {
 
     fn default_test_commandline() -> String {
         Self::default().test_commandline
+    }
+
+    fn default_test_schedule() -> String {
+        Self::default().test_schedule
+    }
+
+    fn default_scheduled_test_branches() -> Vec<String> {
+        Self::default().scheduled_test_branches
     }
 }
 

--- a/templates/circleci.yml
+++ b/templates/circleci.yml
@@ -134,3 +134,20 @@ workflows:
           {%- if conf.bench.run() %}
           - bench
           {%- endif %}
+
+  {%- if !conf.scheduled_test_branches.is_empty() %}
+  scheduled_tests:
+    jobs:
+      {%- for version in conf.versions %}
+      - test:
+          name: test-{{version}}
+          version: {{version}}
+          version_name: {{version}}
+      {%- endfor %}
+    triggers:
+      - schedule:
+          cron: {{conf.test_schedule.as_str()}}
+        filters:
+          branches:
+            only: {{conf.scheduled_test_branches|json}}
+  {%- endif %}

--- a/templates/circleci.yml
+++ b/templates/circleci.yml
@@ -147,7 +147,7 @@ workflows:
     triggers:
       - schedule:
           cron: {{conf.test_schedule.as_str()}}
-        filters:
-          branches:
-            only: {{conf.scheduled_test_branches|json}}
+          filters:
+            branches:
+              only: {{conf.scheduled_test_branches|json}}
   {%- endif %}


### PR DESCRIPTION
This should help me retain my sanity with CI builds: I want to ensure that the project keeps working under stable/nightly rusts, but I don't want to get notified that rustfmt canonical style has changed or that clippy has added new lints.

With a new workflow and a cronjob schedule that runs the build on Sunday by default, I can actually get to this world (: