### PR TITLE
Fix build errors found on 2019-06-09

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -58,7 +58,7 @@ mod tests {
     struct NonSystem {}
 
     impl askama::Template for NonSystem {
-        fn render_into(&self, _writer: &mut fmt::Write) -> askama::Result<()> {
+        fn render_into(&self, _writer: &mut dyn fmt::Write) -> askama::Result<()> {
             Ok(())
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ impl Default for GenerateCommand {
     }
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts = Cmdline::from_args();
     let Cmdline::TemplateCI {
         cmd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } = opts;
 
     let (conf, mut dest) =
-        config::TemplateCIConfig::from_manifest(cargo_manifest.as_ref().map(|pb| pb.as_path()))?;
+        config::TemplateCIConfig::from_manifest(cargo_manifest.as_ref().map(PathBuf::as_path))?;
 
     match cmd.unwrap_or_default() {
         GenerateCommand::TravisCI => {


### PR DESCRIPTION
The cronjob complains, I fix:

- [x] nightly hard-deprecated non-`dyn` trait object references
- [x] nightly clippy complains about a useless closure