### PR TITLE
Allow custom cronjob tasks, support cargo workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ clap = "2.32.0"
 tempfile = "3.0.4"
 custom_error = "1.3.0"
 structopt = "0.2.14"
+toml = "0.5.1"
 
 [build-dependencies]
 askama = { version = "0.7.2", features=["serde-json"]}

--- a/README.md
+++ b/README.md
@@ -30,11 +30,28 @@ By default, the configuration is as follows:
 * Run clippy on `nightly`, but allow failures.
 * Do not run benchmarks (but run them on `nightly` if enabled).
 
+### Configuration sources
+
 You can configure the generated config file by editing your project's
 package metadata in `Cargo.toml`: Everything lives under the key
 `package.metadata.template_ci`. This project has [an example that
 makes clippy failures
 fatal](https://github.com/antifuchs/cargo-template-ci/blob/a8740c68351cd99376c39b5906fde06e271e5e01/Cargo.toml#L27-L28).
+
+If your project uses [Cargo
+workspaces](http://doc.rust-lang.org/1.36.0/book/ch14-03-cargo-workspaces.html),
+it is impossible to add package metadata to the top-level workspace
+configuration file. For that reason, you can also put the template-ci
+config into files in the repository root:
+
+* `.template-ci.toml` or
+* `template-ci.toml`, failing that:
+* `package.metadata.template_ci` in `Cargo.toml`
+
+No configuration value merging is performed: The first configuration
+source that matches causes all other files to be ignored.
+
+## Configuration reference
 
 Here's a list of configurable keys:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::env::current_dir;
+use std::fs::read_to_string;
 use std::io;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -8,6 +10,7 @@ use custom_error::custom_error;
 use serde::de::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
 use serde_json;
+use toml;
 
 trait OptionDeref<T: Deref> {
     fn as_deref(&self) -> Option<&T::Target>;
@@ -138,7 +141,7 @@ impl Default for TemplateCIConfig {
 }
 
 impl<'a> TemplateCIConfig {
-    pub(crate) fn from_manifest(path: Option<&Path>) -> Result<(TemplateCIConfig, PathBuf), Error> {
+    fn from_manifest(path: Option<&Path>) -> Result<(TemplateCIConfig, PathBuf), Error> {
         #[derive(Debug, Deserialize)]
         struct Metadata {
             #[serde(default)]
@@ -166,6 +169,32 @@ impl<'a> TemplateCIConfig {
                 Ok((config.template_ci.unwrap_or_default(), root_dir))
             }
         }
+    }
+
+    fn from_config_file(
+        file_name: impl AsRef<Path>,
+        path: Option<&Path>,
+    ) -> Result<(TemplateCIConfig, PathBuf), Error> {
+        let file_name = file_name.as_ref();
+
+        let default = current_dir()?.join(file_name);
+        let path = path.unwrap_or(&default);
+        let config_src = read_to_string(path)?;
+        let config: TemplateCIConfig = toml::from_str(&config_src)?;
+        Ok((
+            config,
+            path.parent()
+                .expect("Impossible: config file has no parent")
+                .to_path_buf(),
+        ))
+    }
+
+    pub(crate) fn merged_configs(
+        path: Option<&Path>,
+    ) -> Result<(TemplateCIConfig, PathBuf), Error> {
+        TemplateCIConfig::from_config_file("template-ci.toml", path)
+            .or_else(|_| TemplateCIConfig::from_config_file(".template-ci.toml", path))
+            .or_else(|_| TemplateCIConfig::from_manifest(path))
     }
 
     fn default_cache() -> String {
@@ -200,6 +229,7 @@ impl<'a> TemplateCIConfig {
 custom_error! {pub Error
                CargoError{source: cargo_metadata::Error} = "Could not get cargo metadata",
                Deserialization{source: serde_json::Error} = "Could not parse cargo metadata",
+               TOMLDeserialization{source: toml::de::Error} = "Could not parse TOML configuration file",
                IO{source: io::Error} = "IO",
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ impl<T: Deref> OptionDeref<T> for Option<T> {
 #[derive(Debug)]
 pub(crate) struct MatrixEntry {
     pub(crate) run: bool,
+    pub(crate) run_cron: bool,
     pub(crate) version: String,
 
     // TODO: this needs to be shell-escaped!
@@ -35,6 +36,10 @@ pub(crate) trait MatrixEntryExt {
 
     fn run(&self) -> bool {
         self.the_entry().run
+    }
+
+    fn run_cron(&self) -> bool {
+        self.the_entry().run_cron
     }
 
     fn version(&self) -> &str {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,6 +18,7 @@ macro_rules! define_matrix_entry {
                 let cmdline: Option<String> = $commandline_default.into();
                 $name(MatrixEntry {
                     run: $run_default,
+                    run_cron: false,
                     version: String::from($version_default),
                     install_commandline: $install_default.into(),
                     commandline: cmdline.unwrap_or("/bin/false".to_owned()),
@@ -38,6 +39,7 @@ macro_rules! define_matrix_entry {
                 #[derive(Deserialize)]
                 struct DeserializationStruct {
                     run: Option<bool>,
+                    run_cron: Option<bool>,
                     version: Option<String>,
                     install_commandline: Option<String>,
                     commandline: Option<String>,
@@ -46,6 +48,7 @@ macro_rules! define_matrix_entry {
                     fn default() -> Self {
                         DeserializationStruct {
                             run: Some($run_default),
+                            run_cron: Some(false),
                             version: Some(String::from($version_default)),
                             install_commandline: $install_default.into(),
                             commandline: $commandline_default.into(),
@@ -55,6 +58,10 @@ macro_rules! define_matrix_entry {
                 let raw: DeserializationStruct = DeserializationStruct::deserialize(deserializer)?;
                 let res = $name(MatrixEntry {
                     run: raw.run.or(DeserializationStruct::default().run).unwrap(),
+                    run_cron: raw
+                        .run_cron
+                        .or(DeserializationStruct::default().run_cron)
+                        .unwrap(),
                     version: raw
                         .version
                         .or(DeserializationStruct::default().version)

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } = opts;
 
     let (conf, mut dest) =
-        config::TemplateCIConfig::from_manifest(cargo_manifest.as_ref().map(PathBuf::as_path))?;
+        config::TemplateCIConfig::merged_configs(cargo_manifest.as_ref().map(PathBuf::as_path))?;
 
     match cmd.unwrap_or_default() {
         GenerateCommand::TravisCI => {

--- a/templates/circleci.yml
+++ b/templates/circleci.yml
@@ -163,7 +163,9 @@ workflows:
           - bench
           {%- endif %}
           {%- for custom in conf.additional_matrix_entries %}
+          {%- if custom.1.run() %}
           - {{custom.0}}
+          {%- endif %}
           {%- endfor %}
 
   {%- if !conf.scheduled_test_branches.is_empty() %}
@@ -174,6 +176,14 @@ workflows:
           name: test-{{version}}
           version: {{version}}
           version_name: {{version}}
+      {%- endfor %}
+      {%- for custom in conf.additional_matrix_entries %}
+      {%- if custom.1.run_cron() %}
+      - {{custom.0}}:
+          name: "{{custom.0}}"
+          version: "{{custom.1.version()}}"
+          version_name: "{{custom.1.version()}}"
+      {%- endif %}
       {%- endfor %}
     triggers:
       - schedule:


### PR DESCRIPTION
This PR adds two new features:

* Support for custom test tasks that can be run in regular CI, or in a cron job;
* Support for reading configuration from a `.template-ci.toml` file for cargo workspace projects.