### PR TITLE
Add a timeout option to build steps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = "3.0.4"
 custom_error = "1.3.0"
 structopt = "0.2.14"
 toml = "0.5.1"
+humantime-serde = "1.0.0"
 
 [build-dependencies]
 askama = { version = "0.7.2", features=["serde-json"]}

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,6 +323,23 @@ timeout='40min'
     }
 
     #[test]
+    fn parses_cargo_custom_entry_only_mandatory() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+        {
+            let f = create_cargo_file(
+                &dir,
+                r#"
+[package.metadata.template_ci.additional_matrix_entries.something_custom]
+name = "custom_templated_run"
+commandline='echo "running custom tests"'
+"#,
+            )?;
+            let _conf = TemplateCIConfig::from_manifest(Some(&f))?;
+        }
+        Ok(())
+    }
+
+    #[test]
     fn parses_cargo_customizing_stuff() -> Result<(), Error> {
         let dir = tempfile::tempdir()?;
         {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::fs::read_to_string;
 use std::io;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use cargo_metadata;
 use custom_error::custom_error;
@@ -32,6 +33,8 @@ pub(crate) struct MatrixEntry {
     pub(crate) install_commandline: Option<String>,
 
     pub(crate) commandline: String,
+
+    pub(crate) timeout: Option<Duration>,
 }
 
 pub(crate) trait MatrixEntryExt {
@@ -55,6 +58,12 @@ pub(crate) trait MatrixEntryExt {
 
     fn commandline(&self) -> &str {
         &(self.the_entry().commandline)
+    }
+
+    fn timeout(&self) -> Option<String> {
+        self.the_entry()
+            .timeout
+            .map(|to| format!("{}s", to.as_secs()))
     }
 }
 
@@ -305,6 +314,7 @@ bar = "baz"
 name = "custom_templated_run"
 install_commandline='echo "installing for custom tests"'
 commandline='echo "running custom tests"'
+timeout={secs = 90, nanos = 0}
 "#,
             )?;
             let _conf = TemplateCIConfig::from_manifest(Some(&f))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,7 +314,7 @@ bar = "baz"
 name = "custom_templated_run"
 install_commandline='echo "installing for custom tests"'
 commandline='echo "running custom tests"'
-timeout={secs = 90, nanos = 0}
+timeout='40min'
 "#,
             )?;
             let _conf = TemplateCIConfig::from_manifest(Some(&f))?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,6 +44,8 @@ macro_rules! define_matrix_entry {
                     version: Option<String>,
                     install_commandline: Option<String>,
                     commandline: Option<String>,
+
+                    #[serde(with = "humantime_serde")]
                     timeout: Option<Duration>,
                 }
                 impl<'a> Default for DeserializationStruct {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,6 +45,7 @@ macro_rules! define_matrix_entry {
                     install_commandline: Option<String>,
                     commandline: Option<String>,
 
+                    #[serde(default)]
                     #[serde(with = "humantime_serde")]
                     timeout: Option<Duration>,
                 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,6 +22,7 @@ macro_rules! define_matrix_entry {
                     version: String::from($version_default),
                     install_commandline: $install_default.into(),
                     commandline: cmdline.unwrap_or("/bin/false".to_owned()),
+                    timeout: None,
                 })
             }
         }
@@ -43,6 +44,7 @@ macro_rules! define_matrix_entry {
                     version: Option<String>,
                     install_commandline: Option<String>,
                     commandline: Option<String>,
+                    timeout: Option<Duration>,
                 }
                 impl<'a> Default for DeserializationStruct {
                     fn default() -> Self {
@@ -52,6 +54,7 @@ macro_rules! define_matrix_entry {
                             version: Some(String::from($version_default)),
                             install_commandline: $install_default.into(),
                             commandline: $commandline_default.into(),
+                            timeout: None,
                         }
                     }
                 }
@@ -73,6 +76,7 @@ macro_rules! define_matrix_entry {
                         .commandline
                         .or(DeserializationStruct::default().commandline)
                         .expect("Matrix entries need a commandline"),
+                    timeout: raw.timeout.or(DeserializationStruct::default().timeout),
                 });
                 Ok(res)
             }

--- a/templates/circleci.yml
+++ b/templates/circleci.yml
@@ -54,6 +54,9 @@ jobs:
       - run:
           name: Rustfmt
           command: {{conf.rustfmt.commandline()}}
+          {%- if conf.rustfmt.timeout().is_some() %}
+          no_output_timeout: {{conf.rustfmt.timeout().unwrap()}}
+          {%- endif %}
 
   clippy:
     parameters:
@@ -70,6 +73,9 @@ jobs:
       - run:
           name: Clippy
           command: {{conf.clippy.commandline()}}
+          {%- if conf.clippy.timeout().is_some() %}
+          no_output_timeout: {{conf.clippy.timeout().unwrap()}}
+          {%- endif %}
 
   bench:
     parameters:
@@ -86,6 +92,9 @@ jobs:
       - run:
           name: Bench
           command: {{conf.bench.commandline()}}
+          {%- if conf.bench.timeout().is_some() %}
+          no_output_timeout: {{conf.bench.timeout().unwrap()}}
+          {%- endif %}
 
   {%- for custom in conf.additional_matrix_entries %}
   {{custom.0}}:
@@ -107,6 +116,9 @@ jobs:
       - run:
           name: {{custom.1.commandline()}}
           command: {{custom.1.commandline()}}
+          {%- if custom.1.timeout().is_some() %}
+          no_output_timeout: {{custom.1.timeout().unwrap()}}
+          {%- endif %}
   {%- endfor %}
 
   ci_success:


### PR DESCRIPTION
Some things run very long, so let's add a timeout to them (for things that run longer than the 10min circleci default timeout)