### PR TITLE
Don't generate ci_success task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,6 @@ jobs:
           name: echo "running custom tests"
           command: echo "running custom tests"
 
-  ci_success:
-    docker:
-      - image: alpine:latest
-    steps:
-      - run:
-          name: Success
-          command: "echo yay"
-
 workflows:
   continuous_integration:
     jobs:
@@ -183,12 +175,6 @@ workflows:
           name: "something_custom"
           version: stable
           version_name: stable
-      - ci_success:
-          requires:
-          - test-stable
-          - test-nightly
-          - rustfmt
-          - clippy
   scheduled_tests:
     jobs:
       - test:

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@
 # https://app.bors.tech/repositories so bors can see the new repo!
 
 status = [
-  "ci/circleci: ci_success",
+  "continuous_integration",
 ]
 timeout_sec = 300
 delete_merged_branches = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cargo_manifest,
     } = opts;
 
-    let (conf, mut dest) =
-        config::TemplateCIConfig::merged_configs(cargo_manifest.as_ref().map(PathBuf::as_path))?;
+    let (conf, mut dest) = config::TemplateCIConfig::merged_configs(cargo_manifest.as_deref())?;
 
     match cmd.unwrap_or_default() {
         GenerateCommand::TravisCI => {

--- a/templates/circleci.yml
+++ b/templates/circleci.yml
@@ -112,14 +112,6 @@ jobs:
           {%- endif %}
   {%- endfor %}
 
-  ci_success:
-    docker:
-      - image: alpine:latest
-    steps:
-      - run:
-          name: Success
-          command: "echo yay"
-
 workflows:
   continuous_integration:
     jobs:
@@ -151,25 +143,6 @@ workflows:
           version: {{custom.1.version()}}
           version_name: {{custom.1.version()}}
       {%- endfor %}
-      - ci_success:
-          requires:
-          {%- for version in conf.versions %}
-          - test-{{version}}
-          {%- endfor %}
-          {%- if conf.rustfmt.run() %}
-          - rustfmt
-          {%- endif %}
-          {%- if conf.clippy.run() %}
-          - clippy
-          {%- endif %}
-          {%- if conf.bench.run() %}
-          - bench
-          {%- endif %}
-          {%- for custom in conf.additional_matrix_entries %}
-          {%- if custom.1.run() %}
-          - {{custom.0}}
-          {%- endif %}
-          {%- endfor %}
 
   {%- if !conf.scheduled_test_branches.is_empty() %}
   scheduled_tests:


### PR DESCRIPTION
This is a major incompatibility, but I think worth it: Now `cargo template-ci` won't generate a `ci_success` task in circleci anymore. This has the following effects:

* circleci won't wait until the job has been scheduled / container spun up to generate the commit status that e.g. bors can use to merge a PR - faster results!
* all the things that depend on the task need to change. For me, that's mainly bors.toml.