### PR TITLE
Validate bors-ng config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ clap = "2.32.0"
 tempfile = "3.0.4"
 custom_error = "1.3.0"
 structopt = "0.2.14"
-toml = "0.5.1"
+toml = "0.5.6"
 humantime-serde = "1.0.0"
 
 [build-dependencies]

--- a/src/bors.rs
+++ b/src/bors.rs
@@ -1,0 +1,23 @@
+use custom_error::custom_error;
+use io::Read;
+use serde_derive::Deserialize;
+use std::{fs::File, io, path::Path};
+
+#[derive(PartialEq, Debug, Deserialize)]
+pub(crate) struct BorsConfig {
+    pub(crate) status: Vec<String>,
+}
+
+custom_error! {pub Error
+               IOError{source: io::Error} = "could not read bors-ng config",
+               Toml{source: toml::de::Error} = "could not parse bors-ng config as TOML",
+               BadCircleStatusCheck{name: String} = "Bad status check {:?}: Use \"continuous_integration\"",
+               MissingCircleStatusCheck{name: String} = "Missing status check {:?}",
+}
+
+pub(crate) fn config(root: &Path) -> Result<BorsConfig, Error> {
+    let mut f = File::open(root.join("bors.toml"))?;
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)?;
+    Ok(toml::from_str(&buf)?)
+}

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -14,6 +14,7 @@ custom_error! {pub Error
                TemplateError{source: askama::Error} = "could not render template",
                IOError{source: io::Error} = "could not write to CI config",
                PersistError{source: tempfile::PersistError} = "could not overwrite",
+               BorsConfig{source: crate::bors::Error} = "Could not validate bors-ng config: {}",
 }
 
 pub(crate) trait CISystem: askama::Template {
@@ -34,6 +35,13 @@ pub(crate) trait CISystem: askama::Template {
         self.write_preamble(&output)?;
         writeln!(&output, "{}", self.render()?)?;
         output.persist(dest)?;
+        self.validate_config(root)?;
+        Ok(())
+    }
+
+    /// Checks that the configuration that was generated will result
+    /// in working CI.
+    fn validate_config(&self, _root: &Path) -> Result<(), Error> {
         Ok(())
     }
 

--- a/src/ci/circleci.rs
+++ b/src/ci/circleci.rs
@@ -1,5 +1,5 @@
 use serde_derive::Serialize;
-use std::io;
+use std::{io, path::Path};
 
 use super::CISystem;
 use crate::config::MatrixEntryExt;
@@ -26,6 +26,10 @@ impl From<TemplateCIConfig> for CircleCI {
 impl CISystem for CircleCI {
     fn write_preamble(&self, mut _output: impl io::Write) -> Result<(), super::Error> {
         Ok(())
+    }
+
+    fn config_file_name(&self, root: &Path) -> std::path::PathBuf {
+        root.join(".circleci/config.yml")
     }
 }
 

--- a/src/ci/travis.rs
+++ b/src/ci/travis.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, path::Path};
 
 use super::CISystem;
 use crate::config::MatrixEntryExt;
@@ -21,5 +21,9 @@ impl From<TemplateCIConfig> for TravisCI {
 impl CISystem for TravisCI {
     fn write_preamble(&self, mut _output: impl io::Write) -> Result<(), super::Error> {
         Ok(())
+    }
+
+    fn config_file_name(&self, root: &Path) -> std::path::PathBuf {
+        root.join(".travis.yml")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 #[macro_use]
 mod macros;
 
+mod bors;
 mod ci;
 mod config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,18 +49,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cargo_manifest,
     } = opts;
 
-    let (conf, mut dest) = config::TemplateCIConfig::merged_configs(cargo_manifest.as_deref())?;
+    let (conf, dest) = config::TemplateCIConfig::merged_configs(cargo_manifest.as_deref())?;
 
-    match cmd.unwrap_or_default() {
-        GenerateCommand::TravisCI => {
-            dest.push(".travis.yml");
-            TravisCI::from(conf).render_into_config_file(dest)?;
-        }
-        GenerateCommand::CircleCI => {
-            dest.push(".circleci");
-            dest.push("config.yml");
-            CircleCI::from(conf).render_into_config_file(dest)?;
-        }
+    let res = match cmd.unwrap_or_default() {
+        GenerateCommand::TravisCI => TravisCI::from(conf).render_into_config_file(&dest),
+        GenerateCommand::CircleCI => CircleCI::from(conf).render_into_config_file(&dest),
+    };
+    if let Err(e) = res {
+        eprintln!("Generating CI config failed. {}", e);
+        return Err(e.into());
     }
     Ok(())
 }


### PR DESCRIPTION
Now that circleci uses a different status check, I don't want to get that bors timeout every time I update the CI config. With this PR, the tool errors if the bors config doesn't match the new circleci config.